### PR TITLE
parallel scaling comparison

### DIFF
--- a/R/preText.R
+++ b/R/preText.R
@@ -54,7 +54,8 @@ preText <- function(preprocessed_documents,
     scaling_results <- scaling_comparison(dfm_object_list,
                                           dimensions = 2,
                                           distance_method = distance_method,
-                                          verbose = verbose)
+                                          verbose = verbose,
+                                          cores = cores)
 
     # extract distance matrices
     distance_matrices <- scaling_results$distance_matrices


### PR DESCRIPTION
This is a separate/standalone contribution from the other PR. Here, I split-off the distance matrix and position scaling code into its own function. This allows us to parallelize the `scaling_comparison` function.

In my current application, I'm dealing with thousands of large documents, and building distance matrices takes **_forever_**. Because the data doesn't quite fit in my laptop's memory, I have to run this on a large memory instance on the web, and I'd like to be able to parallelize the process to save money.