### PR TITLE
Change namespace for `coef()` call

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: preText
 Type: Package
 Title: Diagnostics to Assess the Effects of Text Preprocessing Decisions
-Version: 0.6.1
+Version: 0.6.2
 Date: 2017-11-13
 Author: Matthew J. Denny <mdenny@psu.edu>, Arthur Spirling
     <as9934@nyu.edu>,

--- a/R/preprocessing_choice_regression.R
+++ b/R/preprocessing_choice_regression.R
@@ -69,7 +69,7 @@ preprocessing_choice_regression <- function(Y,
     fit <- lm(formula = form, data = DATA)
     cat("The R^2 for this model is:",summary(fit)$r.squared,"\n")
     sds <- summary(fit)$coefficients[,2]
-    results1 <- cbind( quanteda::coef(fit),  sds)
+    results1 <- cbind( stats::coef(fit),  sds)
     results1 <- as.data.frame(results1,
                               stringsAsFactors = FALSE)
     results <- cbind(results1,var_names)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,12 +1,19 @@
+## Submission notes
+
+Fixes a bug that clashes with the newest version of the **quanteda** package.
+
 ## Test environments
-* local OS X install, R 3.4.2
+
+* local OS X install, R 3.4.3
 * win-builder (devel and release)
 * travis CI, R 3.4.2
 
 ## R CMD check results
+
 There were no ERRORs or WARNINGs on Windows, OS X, or Linux. 
 
 ## Downstream dependencies
+
 The package update does not cause any issues because it does not have any downstream dependencies. 
 
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -6,7 +6,7 @@ Fixes a bug that clashes with the newest version of the **quanteda** package.
 
 * local OS X install, R 3.4.3
 * win-builder (devel and release)
-* travis CI, R 3.4.2
+* travis CI, R 3.4.3
 
 ## R CMD check results
 


### PR DESCRIPTION
The object on which this is called is an `lm` object, but the code calls `quanteda::coef()`.  It should be `stats::coef()`.

@matthewjdenny would be great if you could `devtools::submit_cran()` this ASAP as I just submitted **quanteda** v1.0 and the only `revdep` failure is your package's vignette. Thanks!!

BTW the fact that the package passes check but the vignette fails means you didn't catch this in your unit tests! Time to add a test.