### PR TITLE
Debugging build_distance_objects()

### DIFF
--- a/R/scaling_comparison.R
+++ b/R/scaling_comparison.R
@@ -1,6 +1,7 @@
 build_distance_objects <- function(cur_dfm, distance_method, dimensions) {
     if (distance_method == "cosine") {
         simil <- quanteda::textstat_simil(cur_dfm, method = distance_method)
+        simil[is.na(simil)] <- 0
     } else {
         simil <- proxy::simil(as.matrix(cur_dfm), method = distance_method)
     }


### PR DESCRIPTION
Dealing with cases were there is no similarity for a document in the dfm and therefore NA is returned by quanteda::textstat_simil(). Fixing this by setting all NAs to 0 as a default. This would be a common problem for sparse DFMs