### PR TITLE
Improving preText_test speed, keeping order in memory

### DIFF
--- a/R/factorial_preprocessing.R
+++ b/R/factorial_preprocessing.R
@@ -100,7 +100,7 @@ factorial_preprocessing <- function(text,
             labels[i] <- str
         }
     } else {
-        cat("Preprocessing", length(texts), "documents 64 different ways...\n")
+        cat("Preprocessing", length(text), "documents 64 different ways...\n")
         choices <- data.frame(expand.grid(list(removePunctuation = c(TRUE,FALSE),
                                                removeNumbers = c(TRUE,FALSE),
                                                lowercase = c(TRUE,FALSE),

--- a/R/preText_test.R
+++ b/R/preText_test.R
@@ -68,42 +68,32 @@ preText_test <- function(distance_matrices,
 
     # figures out which entry in the distance matrix has the largest difference
     # from it to the base case entry.
-    get_max_difference <- function (dist_matrix,
-                                    baseline) {
-        temp <- abs(dist_matrix - baseline)
-        temp <- temp[lower.tri(temp)]
-        ordering <- order(temp, decreasing = TRUE)
-        return(ordering)
+    get_max_difference <- function(dist_matrix, baseline) {
+      temp <- abs(dist_matrix - baseline)
+      temp <- temp[lower.tri(temp)]
+      ordering <- order(temp, decreasing = TRUE)
+      return(ordering)
     }
 
     # find out the average rank of this distance difference in all of the other
     # preprocessing steps. Returns the average (absolute) rank difference
-    compare_top_difference <- function(distance_matrices,
-                                       baseline,
-                                       i,
-                                       baseline_index,
-                                       most_different_index,
-                                       place) {
-        # create indices to loop through
-        inds <- 1:length(distance_matrices)
-        inds <- inds[-c(baseline_index, i)]
-
-        rank_of_top_difference <- rep(0,length(inds))
-        counter <- 1
-        for (j in inds) {
-
-            dist_mat <- distance_matrices[[j]]
-            comparison_ordering <- get_max_difference(dist_mat, baseline)
-            rank_val <- which(comparison_ordering == most_different_index)
-            rank_val <- abs(rank_val - place)
-            rank_of_top_difference[counter] <- rank_val
-            counter <- counter + 1
-        }
-        rank_of_top_difference <- rank_of_top_difference/length(lower.tri(dist_mat))
-        average_rank <- mean(rank_of_top_difference)
-
-        return(list(ave_diff = average_rank,
-                    ave_diff_SE = sd(rank_of_top_difference)))
+    compare_top_difference <- function(distance_matrices, baseline, 
+                                       i, baseline_index, most_different_index, place,  ordering_list) {
+      inds <- 1:length(distance_matrices)
+      inds <- inds[-c(baseline_index, i)] #remove baselin and current dist_m
+      rank_of_top_difference <- rep(0, length(inds))
+      counter <- 1
+      for (j in inds) {
+        ## dist_mat <- distance_matrices[[j]]
+        comparison_ordering <- ordering_list[[j]]
+        rank_val <- which(comparison_ordering == most_different_index)
+        rank_val <- abs(rank_val - place)
+        rank_of_top_difference[counter] <- rank_val
+        counter <- counter + 1
+      }
+      rank_of_top_difference <- rank_of_top_difference/length(lower.tri(distance_matrices[[j]])) #normalise rank of diffenrence by total number of diff
+      average_rank <- mean(rank_of_top_difference) # mean diff
+      return(list(ave_diff = average_rank, ave_diff_SE = sd(rank_of_top_difference)))
     }
 
 
@@ -167,43 +157,39 @@ preText_test <- function(distance_matrices,
             print(scores)
         } else {
             # populate the scores vector
-            for (i in 1:num_dms) {
-                if (verbose) {
-                    cat("Currently working on DFM:",i,"of",num_dms,"\n")
-                }
-                ptm <- proc.time()
-                # if we are not dealing with the baseline
-                if (i != baseline_index) {
-                    dist_matrix <- distance_matrices[[i]]
-                    ordering <- get_max_difference(dist_matrix,
-                                                   baseline)
-
-                    samp <- 1:num_comparisons
-                    #samp <- sample(1:length(ordering),num_comparisons)
-                    cur_scores <- rep(0,num_comparisons)
-                    cur_score_SE <- rep(0,num_comparisons)
-                    for (k in 1:num_comparisons) {
-                        most_different_index <- ordering[samp[k]]
-                        result <- compare_top_difference(distance_matrices,
-                                                         baseline,
-                                                         i,
-                                                         baseline_index,
-                                                         most_different_index,
-                                                         place = samp[k])
-                        cur_scores[k] <- result$ave_diff
-                        cur_score_SE[k] <- result$ave_diff_SE
-                    }
-                    if (verbose) {
-                        cat("\n")
-                    }
-                    scores[score_counter] <- mean(cur_scores)
-                    score_SE[score_counter] <- mean(cur_score_SE)
-                    score_counter <- score_counter + 1
-                }
-                t2 <- proc.time() - ptm
-
-                if (verbose) {
-                    cat("Complete in:",t2[[3]],"seconds...\n")
+   for (i in 1:num_dms) {
+          if (i != baseline_index) {
+            ordering_list[[i]] <- get_max_difference(distance_matrices[[i]], baseline)
+          }}
+        for (i in 1:num_dms	) {
+          if (verbose) {
+            cat("Currently working on DFM:", i, "of", num_dms, 
+                "\n")
+          }
+          ptm <- proc.time()
+          if (i != baseline_index) {
+            dist_matrix <- distance_matrices[[i]]
+            ordering <- ordering_list[[i]]
+            samp <- 1:num_comparisons
+            cur_scores <- rep(0, num_comparisons)
+            cur_score_SE <- rep(0, num_comparisons)
+            for (k in 1:num_comparisons) {
+              most_different_index <- ordering[samp[k]]
+              result <- compare_top_difference(distance_matrices, 
+                                               baseline, i, baseline_index, most_different_index, 
+                                               place = samp[k], ordering_list )
+              cur_scores[k] <- result$ave_diff
+              cur_score_SE[k] <- result$ave_diff_SE
+            }
+            if (verbose) {
+              cat("\n")
+            }
+            scores[score_counter] <- mean(cur_scores)
+            score_SE[score_counter] <- mean(cur_score_SE)
+            score_counter <- score_counter + 1 }
+          t2 <- proc.time() - ptm
+          if (verbose) {
+            cat("Complete in:", t2[[3]], "seconds...\n") 
                 }
             }
         }

--- a/R/preText_test.R
+++ b/R/preText_test.R
@@ -110,6 +110,8 @@ preText_test <- function(distance_matrices,
     scores <- rep(0,(num_dms - 1))
     score_SE <- rep(0,(num_dms - 1))
     score_counter <- 1
+    ordering_list  <- list()
+
     if (method == "top") {
         # populate the scores vector
         for(i in 1:num_dms) {


### PR DESCRIPTION
Hi,

The speed of preText_test can be improved by applying get_max_difference on the entire list of distance matrix onces instead of each run. With 128 preprocessing step the process is ~17 times faster. 

I've only modified the "single core" version. 

This is my first pull request, I hope I'm doing this right. 

al